### PR TITLE
add trailing slash to authorize link

### DIFF
--- a/example/templates/example/consumer.html
+++ b/example/templates/example/consumer.html
@@ -36,7 +36,7 @@
           type="url" class="form-control" required />
           <span class="help-block">
             The url to the authorization page, it's ok if it points to localhost
-            (e.g. http://localhost:8000/o/authorize).
+            (e.g. http://localhost:8000/o/authorize/).
           </span>
           {{ form.authorization_url.errors }}
         </div>


### PR DESCRIPTION
The trailing slash is required, or the resulting link is broken. This may hang up people using the tutorial who get confused.
